### PR TITLE
Fixed an issue when installing the logviewer

### DIFF
--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -97,7 +97,7 @@ class LogViewerServiceProvider extends PackageServiceProvider
     /**
      * Register configs.
      */
-    protected function registerConfig()
+    protected function registerConfig($seperator = '.')
     {
         $this->mergeConfigFrom($this->getConfigFile(), $this->package);
     }


### PR DESCRIPTION
An errors was thrown when using the logviewer

[ErrorException] Declaration of Arcanedev\LogViewer\LogViewerServiceProvider::registerConfig() should be compatible with Arcanedev\Support\PackageServiceProvider::registerConfig($separator = '.')