### PR TITLE
Fix 404 error on momentjs load

### DIFF
--- a/resources/views/_template/master.blade.php
+++ b/resources/views/_template/master.blade.php
@@ -28,8 +28,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/locale/{{ trans()->getLocale() }}.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.11.1/moment-with-locales.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.15.35/js/bootstrap-datetimepicker.min.js"></script>
     <script>


### PR DESCRIPTION
If getLocale returns locale which doesn't exist on cloudflare for momentjs (in my case it was en-us) we get 404, because that file doesn't exist. Momentjs has it's own fallback to default language implemented: https://github.com/moment/moment/issues/1031

So by including moment-with-locales.min.js we can avoid 404 and have graceful fallback to en language