### PR TITLE
[Fix #44] Fixing the Division by zero error when the log file is empty

### DIFF
--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -183,7 +183,7 @@ class LogViewerController extends Controller
             $percents[$level] = [
                 'name'    => $names[$level],
                 'count'   => $count,
-                'percent' => round(($count / $all) * 100, 2),
+                'percent' => $all ? round(($count / $all) * 100, 2) : 0,
             ];
         }
 


### PR DESCRIPTION
See #44