### PR TITLE
Changed redirect to follow action instead of route.

### DIFF
--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -101,7 +101,7 @@ class LogViewerController extends Controller
         $log = $this->getLogOrFail($date);
 
         if ($level == 'all')
-            return redirect()->route('log-viewer::logs.show', [$date]);
+            return redirect()->action( '\\' . __CLASS__ . '@show', ['date' => $date]);
 
         $levels  = $this->logViewer->levelsNames();
         $entries = $this->logViewer


### PR DESCRIPTION
This change is useful when:
`routes.enabled = false` and the name of the show route has changed (for example `admin.logs.show`).

Another approach is to do:
`return $this->show($date)`
instead of:
`return redirect()->action( '\\' . __CLASS__ . '@show', ['date' => $date]);`