### PR TITLE
Fix html entities in stack traces

### DIFF
--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -106,7 +106,7 @@
                                     <tr>
                                         <td colspan="5" class="stack">
                                             <div class="stack-content collapse" id="log-stack-{{ $key }}">
-                                                {!! preg_replace("/\n/", '<br>', $entry->stack) !!}
+                                                {!! nl2br(htmlentities($entry->stack), false) !!}
                                             </div>
                                         </td>
                                     </tr>


### PR DESCRIPTION
Sometimes (eg. in guzzle requests) exception's stack trace can have xml or html data that will be broken if there is no html entities conversion.