### PR TITLE
logviewer's middleware can now be controlled using .env file

### DIFF
--- a/_docs/2.Configuration.md
+++ b/_docs/2.Configuration.md
@@ -87,7 +87,6 @@ return [
 ```
 
 ## Route
-
 ```php
 <?php
 
@@ -104,13 +103,25 @@ return [
         'attributes' => [
             'prefix'     => 'log-viewer',
 
-            'middleware' => null,
+            'middleware' => env('ARCANEDEV_LOGVIEWER_MIDDLEWARE') ? explode(',', env('ARCANEDEV_LOGVIEWER_MIDDLEWARE')) : null,
         ],
     ],
 
     // ...
 ];
 ```
+
+By default no middleware is added to `log-viewer` route. If you need middlewares you just have to add a `ARCANEDEV_LOGVIEWER_MIDDLEWARE` key to your `.env` file and add middlewares as comma separated values (no space).
+Example 1: one middleware
+```
+ARCANEDEV_LOGVIEWER_MIDDLEWARE=web
+```
+
+Example 2: three middlewares
+```
+ARCANEDEV_LOGVIEWER_MIDDLEWARE=web,auth,myCustomMiddleware
+```
+
 
 ## Pagination
 

--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -38,7 +38,7 @@ return [
         'attributes' => [
             'prefix'     => 'log-viewer',
 
-            'middleware' => null,
+            'middleware' => env('ARCANEDEV_LOGVIEWER_MIDDLEWARE') ? explode(',', env('ARCANEDEV_LOGVIEWER_MIDDLEWARE')) : null,
         ],
     ],
 


### PR DESCRIPTION
There doesn't seem to be any way of specifying a middleware from an .`env` file.

```php
<?php
// config/log-viewer.php
return [
    // ...
    /* -------------------------------------------------------------------------
     |  Route
     | -------------------------------------------------------------------------
     */
    'route'         => [
        'enabled'    => true,
        'attributes' => [
            'prefix'     => 'log-viewer',
            'middleware' => null,  // <========= set to null
        ],
    ],
];
```

This PR adds support for controlling above route's middleware param through a  `ARCANEDEV_LOGVIEWER_MIDDLEWARE` setting in `.env`

Example use:
`ARCANEDEV_LOGVIEWER_MIDDLEWARE=web,auth,isAdmin`

Should I also update README file?

Thanks!