### PR TITLE
Fix undefined constant GLOB_BRACE on Alpine Linux

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -14,3 +14,8 @@ if ( ! defined('REGEX_DATETIME_PATTERN')) {
         REGEX_DATE_PATTERN . ' ' . REGEX_TIME_PATTERN // YYYY-MM-DD HH:MM:SS
     );
 }
+
+// Fix undefined constant GLOB_BRACE exception on Alpine Linux
+if ( ! defined('GLOB_BRACE')) {
+    define('GLOB_BRACE', 0);
+}

--- a/constants.php
+++ b/constants.php
@@ -15,7 +15,7 @@ if ( ! defined('REGEX_DATETIME_PATTERN')) {
     );
 }
 
-// Fix undefined constant GLOB_BRACE exception on Alpine Linux
+// Fix undefined constant GLOB_BRACE exception on Alpine Linux (https://bugs.php.net/bug.php?id=72095)
 if ( ! defined('GLOB_BRACE')) {
     define('GLOB_BRACE', 0);
 }

--- a/src/Utilities/Filesystem.php
+++ b/src/Utilities/Filesystem.php
@@ -288,7 +288,7 @@ class Filesystem implements FilesystemContract
     private function getFiles($pattern)
     {
         $files = $this->filesystem->glob(
-            $this->storagePath.DS.$pattern, defined('GLOB_BRACE') ? GLOB_BRACE : 0
+            $this->storagePath.DS.$pattern, GLOB_BRACE
         );
 
         return array_filter(array_map('realpath', $files));


### PR DESCRIPTION
Fix undefined constant GLOB_BRACE exception on Alpine Linux.  

```
ErrorException in /var/www/html/vendor/arcanedev/log-viewer/src/Utilities/Filesystem.php line 285:
Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE'
```

After I researching the problem, I found that this is the bug([https://bugs.php.net/bug.php?id=72095](https://bugs.php.net/bug.php?id=72095)) on Alpine Linux.

thx for your project.