### PR TITLE
support locale setting by env file

### DIFF
--- a/src/Tables/AbstractTable.php
+++ b/src/Tables/AbstractTable.php
@@ -82,7 +82,9 @@ abstract class AbstractTable implements TableContract
      */
     protected function setLocale($locale)
     {
-        if (is_null($locale) || $locale === 'auto') {
+        if (!empty(getenv('ARCANEDEV_LOGVIEWER_LOCALE'))) {
+            $locale = getenv('ARCANEDEV_LOGVIEWER_LOCALE');
+        } elseif (is_null($locale) || $locale === 'auto') {
             $locale = app()->getLocale();
         }
 

--- a/src/Utilities/LogLevels.php
+++ b/src/Utilities/LogLevels.php
@@ -96,8 +96,11 @@ class LogLevels implements LogLevelsContract
      */
     public function setLocale($locale)
     {
-        $this->locale = is_null($locale) ? 'auto' : $locale;
-
+        if (!empty(getenv('ARCANEDEV_LOGVIEWER_LOCALE'))) {
+            $this->locale = getenv('ARCANEDEV_LOGVIEWER_LOCALE');
+        } else {
+            $this->locale = is_null($locale) ? 'auto' : $locale;
+        }
         return $this;
     }
 


### PR DESCRIPTION
This PR adds support that log-viewer is running in different locale from the application.

Example:
Locale setting is `ja` by `config/app.php`, but you wanna use `en` in log-viewer.
If `ARCANEDEV_LOGVIEWER_LOCALE` is defined in `.env` , you can use `en` in log-viewer.

```php
// config/app.php
<?php
return [
    'locale' => 'ja', // you don't wanna use Japanese in log-viewer
];
```

```sh
# .env
ARCANEDEV_LOGVIEWER_LOCALE=en
```