### PR TITLE
Fixed typo in requirements check message

### DIFF
--- a/src/Utilities/LogChecker.php
+++ b/src/Utilities/LogChecker.php
@@ -245,7 +245,7 @@ class LogChecker implements LogCheckerContract
     {
         if ($this->isDaily()) return;
 
-        $this->messages['handler'] = 'You should set the log handler to `daily` mode. Please check the LogViwer wiki page (Requirements) for more details.';
+        $this->messages['handler'] = 'You should set the log handler to `daily` mode. Please check the LogViewer wiki page (Requirements) for more details.';
     }
 
     /**


### PR DESCRIPTION
When checking requirements  with `artisan log-viewer:check` I noticed a small typo in the error message (a missing *e*).