### PR TITLE
README fix for PHP 7.3 installations

### DIFF
--- a/_docs/1.Installation-and-Setup.md
+++ b/_docs/1.Installation-and-Setup.md
@@ -51,7 +51,7 @@ Laravel uses the [Monolog PHP logging library](https://github.com/Seldaek/monolo
 
 You can install this package via [Composer](http://getcomposer.org/) by running this command: `composer require arcanedev/log-viewer:{x.x}` where **x.x** is the version compatible with your laravel's version. 
 
-E.g `composer require arcanedev/log-viewer:4.6.1` for Laravel **v5.7** (minimum version for PHP 7.3 is 4.6.1 due to a [bug](https://github.com/ARCANEDEV/LogViewer/issues/234)).
+E.g `composer require arcanedev/log-viewer:~4.6.0` for Laravel **v5.7**.
 
 See the [Version compatibility](#version-compatibility) table above to choose the correct version.
 

--- a/_docs/1.Installation-and-Setup.md
+++ b/_docs/1.Installation-and-Setup.md
@@ -51,7 +51,7 @@ Laravel uses the [Monolog PHP logging library](https://github.com/Seldaek/monolo
 
 You can install this package via [Composer](http://getcomposer.org/) by running this command: `composer require arcanedev/log-viewer:{x.x}` where **x.x** is the version compatible with your laravel's version. 
 
-E.g `composer require arcanedev/log-viewer:4.6` for Laravel **v5.7**. 
+E.g `composer require arcanedev/log-viewer:4.6.1` for Laravel **v5.7** (minimum version for PHP 7.3 is 4.6.1 due to a [bug](https://github.com/ARCANEDEV/LogViewer/issues/234)).
 
 See the [Version compatibility](#version-compatibility) table above to choose the correct version.
 


### PR DESCRIPTION
The current installation guide will fail for PHP 7.3, so I added this fix: It tells the user to do a composer require to version `4.6`, which will install 4.6.0. This version has an [incompatibility issue](https://github.com/ARCANEDEV/LogViewer/issues/234) with PHP 7.3 that has been fixed in 4.6.1, so it makes sense to require that by default.

Maybe there is a better solution to require the *latest stable* of 4.6 rather than setting the .1 manually. Feel free to edit this commit :)