### PR TITLE
Update LogViewerController@search to be able to match multiple words in query

### DIFF
--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -141,7 +141,7 @@ class LogViewerController extends Controller
     public function search(Request $request, $date, $level = 'all')
     {
         $query   = $request->get('query');
-        
+
         if (is_null($query))
             return redirect()->route($this->showRoute, [$date]);
 

--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -145,20 +145,11 @@ class LogViewerController extends Controller
         if (is_null($query))
             return redirect()->route($this->showRoute, [$date]);
 
-        $needles = explode(' ', $query);
-
         $log     = $this->getLogOrFail($date);
         $levels  = $this->logViewer->levelsNames();
+        $needles = explode(' ', $query);
         $entries = $log->entries($level)->filter(function ( LogEntry $value) use ($needles) {
-
-            foreach($needles as $needle){
-                if(!Str::contains($value->header, $needle)){
-                    return false;
-                }
-            }
-
-            return true;
-            
+            return Str::containsAll($value->header, $needles);
         })->paginate($this->perPage);
 
         return $this->view('show', compact('level', 'log', 'query', 'levels', 'entries'));

--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -141,14 +141,24 @@ class LogViewerController extends Controller
     public function search(Request $request, $date, $level = 'all')
     {
         $query   = $request->get('query');
-
+        
         if (is_null($query))
             return redirect()->route($this->showRoute, [$date]);
 
+        $needles = explode(' ', $query);
+
         $log     = $this->getLogOrFail($date);
         $levels  = $this->logViewer->levelsNames();
-        $entries = $log->entries($level)->filter(function (LogEntry $value) use ($query) {
-            return Str::contains($value->header, $query);
+        $entries = $log->entries($level)->filter(function ( LogEntry $value) use ($needles) {
+
+            foreach($needles as $needle){
+                if(!Str::contains($value->header, $needle)){
+                    return false;
+                }
+            }
+
+            return true;
+            
         })->paginate($this->perPage);
 
         return $this->view('show', compact('level', 'log', 'query', 'levels', 'entries'));

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -93,6 +93,29 @@ class RoutesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_search_using_shuffled_query()
+    {
+        $date     = '2015-01-01';
+        $level    = 'all';
+        $query    = explode(' ', 'This is a error log');
+        shuffle($query);
+        $query    = implode(' ', $query);
+
+        $response = $this->get(route('log-viewer::logs.search', compact('date', 'level', 'query')));
+        $response->assertSuccessful();
+
+        /** @var \Illuminate\View\View $view */
+        $view = $response->getOriginalContent();
+
+        static::assertArrayHasKey('entries', $view->getData());
+
+        /** @var  \Illuminate\Pagination\LengthAwarePaginator  $entries */
+        $entries = $view->getData()['entries'];
+
+        static::assertCount(1, $entries);
+    }
+
+    /** @test */
     public function it_must_redirect_on_all_level()
     {
         $date     = '2015-01-01';


### PR DESCRIPTION
Description:
Currently the search function on returns a log if the whole query string is contained in the entry. By exploding the query string and checking if the $value->header contains that strings you are able to search multiple words found anywhere in the $value->header. This allows you to search, say for instance, "(customername) (username) (error_type/exception_class)" and regardless of the order of that query you can find any entry that matches all 3. Basically, it is doing three queries and if each needle of that query is matched then an entry has been matched.

I could fork the could and do this myself. I just thought for me it would be easier and your repo would benefit from its implementation.

Steps To Reproduce:
to add this functionality, update the LogViewerController@search() to look like:

```
public function search(Request $request, $date, $level = 'all')
{
    $query   = $request->get('query');
    
    if (is_null($query))
        return redirect()->route($this->showRoute, [$date]);

    $needles = explode(' ', $query);

    $log     = $this->getLogOrFail($date);
    $levels  = $this->logViewer->levelsNames();
    $entries = $log->entries($level)->filter(function ( LogEntry $value) use ($needles) {

        foreach($needles as $needle){
            if(!Str::contains($value->header, $needle)){
                return false;
            }
        }

        return true;
        
    })->paginate($this->perPage);

    return $this->view('show', compact('level', 'log', 'query', 'levels', 'entries'));
}
```