### PR TITLE
fixing service provider error when running phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Arcanedev\\LogViewer\\LogViewerServiceProvider",
-                "Arcanedev\\LogViewer\\Providers\\DeferredServicesProvider"
+                "Arcanedev\\LogViewer\\LogViewerServiceProvider"
             ]
         }
     }

--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -36,6 +36,8 @@ class LogViewerServiceProvider extends PackageServiceProvider
 
         $this->registerConfig();
 
+        $this->registerProvider(Providers\DeferredServicesProvider::class);
+
         $this->registerProvider(Providers\RouteServiceProvider::class);
 
         $this->registerCommands([


### PR DESCRIPTION
Hi, i'm on laravel 6, just updated this awesome package, but having this error when i'm running phpunit:

```
Target [Arcanedev\LogViewer\Contracts\LogViewer] is not instantiable while building [Arcanedev\LogViewer\Commands\PublishCommand].  
```

I've been able to manually fix this by directly edit inside vendor directory, hope this help