### PR TITLE
Parse and display context in log viewer

### DIFF
--- a/resources/views/bootstrap-4/show.blade.php
+++ b/resources/views/bootstrap-4/show.blade.php
@@ -146,6 +146,11 @@
                                                 <i class="fa fa-toggle-on"></i> Stack
                                             </a>
                                         @endif
+                                        @if ($entry->hasContext())
+                                            <a class="btn btn-sm btn-light" role="button" data-toggle="collapse" href="#context-{{ $key }}" aria-expanded="false" aria-controls="context-{{ $key }}">
+                                                <i class="fa fa-toggle-on"></i> Context
+                                            </a>
+                                        @endif
                                     </td>
                                 </tr>
                                 @if ($entry->hasStack())
@@ -153,6 +158,17 @@
                                         <td colspan="5" class="stack py-0">
                                             <div class="stack-content collapse" id="log-stack-{{ $key }}">
                                                 {!! $entry->stack() !!}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endif
+                                @if ($entry->hasContext())
+                                    <tr>
+                                        <td colspan="5" class="stack py-0">
+                                            <div class="stack-content collapse" id="context-{{ $key }}">
+                                                @php
+                                                    dump($entry->context)
+                                                @endphp
                                             </div>
                                         </td>
                                     </tr>

--- a/src/Entities/LogEntry.php
+++ b/src/Entities/LogEntry.php
@@ -30,7 +30,7 @@ class LogEntry implements Arrayable, Jsonable, JsonSerializable
     /** @var string */
     public $header;
 
-    /** @var string */
+    /** @var object */
     public $context;
 
     /** @var string */


### PR DESCRIPTION
Parse the "context" data associated with a log entry and make it available on the front end. I've used `dump` for displaying the context/object, but feel free to change that. I also only made these changes in the bootstrap 4 blades, not in bootstrap 3.

Closes #312