### PR TITLE
Context log entry, Str helper instead of Regexp

### DIFF
--- a/src/Entities/LogEntry.php
+++ b/src/Entities/LogEntry.php
@@ -309,10 +309,10 @@ class LogEntry implements Arrayable, Jsonable, JsonSerializable
             $header = trim(str_replace($out[0], '', $header));
         }
 
-        // EXTRACT CONTEXT (Regex from https://stackoverflow.com/a/21995025)
-        preg_match_all('/{(?:[^{}]|(?R))*}/x', $header, $out);
-        if (isset($out[0][0]) && ! is_null($context = json_decode($out[0][0], true))) {
-            $header = str_replace($out[0][0], '', $header);
+        // EXTRACT CONTEXT
+        $contextJson = '{'.\Illuminate\Support\Str::after($header, '{');
+        if (! is_null($context = json_decode($contextJson, true))) {
+            $header = str_replace($contextJson, '', $header);
             $this->setContext($context);
         }
 


### PR DESCRIPTION
I had some memory issues, when the json was too long json_encodes returns null, some explanation here:
https://stackoverflow.com/questions/7620910/regexp-in-preg-match-function-returning-browser-error/7627962#7627962