### PR TITLE
Fix: Line break

### DIFF
--- a/views/bootstrap-4/_master.blade.php
+++ b/views/bootstrap-4/_master.blade.php
@@ -210,6 +210,10 @@
         .badge.badge-env {
             background-color: #6A1B9A;
         }
+        
+        #entries {
+            overflow-wrap: anywhere;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
When outputting a long line to the logs, the table is very stretched, and to collapse the stacktrace, you have to scroll. it is very not convenient.

Before:
![before](http://ipic.su/img/img7/fs/log-image-1.1590481625.jpg)

And this is the easiest version.
Sometimes cookies need to be displayed, and these are already thousands of characters.

After:
![after](http://ipic.su/img/img7/fs/log-image-2.1590481664.jpg)
