### PR TITLE
Page load speed improve

### DIFF
--- a/src/LogViewer.php
+++ b/src/LogViewer.php
@@ -8,6 +8,8 @@ use Arcanedev\LogViewer\Contracts\Utilities\Filesystem as FilesystemContract;
 use Arcanedev\LogViewer\Contracts\Utilities\Factory as FactoryContract;
 use Arcanedev\LogViewer\Contracts\Utilities\LogLevels as LogLevelsContract;
 use Arcanedev\LogViewer\Contracts\LogViewer as LogViewerContract;
+use Arcanedev\LogViewer\Entities\Log;
+use Arcanedev\LogViewer\Exceptions\LogNotFoundException;
 
 /**
  * Class     LogViewer
@@ -182,7 +184,12 @@ class LogViewer implements LogViewerContract
      */
     public function get($date)
     {
-        return $this->factory->log($date);
+        $dates = $this->filesystem->dates(true);
+        if (!isset($dates[$date])) {
+            throw new LogNotFoundException("Log not found in this date [$date]");
+        }
+
+        return new Log($date, $dates[$date], $this->filesystem->read($date));
     }
 
     /**
@@ -195,7 +202,7 @@ class LogViewer implements LogViewerContract
      */
     public function entries($date, $level = 'all')
     {
-        return $this->factory->entries($date, $level);
+        return $this->get($date)->entries($level);
     }
 
     /**
@@ -279,7 +286,7 @@ class LogViewer implements LogViewerContract
      */
     public function dates()
     {
-        return $this->factory->dates();
+        return $this->filesystem->dates();
     }
 
     /**

--- a/src/LogViewer.php
+++ b/src/LogViewer.php
@@ -8,8 +8,6 @@ use Arcanedev\LogViewer\Contracts\Utilities\Filesystem as FilesystemContract;
 use Arcanedev\LogViewer\Contracts\Utilities\Factory as FactoryContract;
 use Arcanedev\LogViewer\Contracts\Utilities\LogLevels as LogLevelsContract;
 use Arcanedev\LogViewer\Contracts\LogViewer as LogViewerContract;
-use Arcanedev\LogViewer\Entities\Log;
-use Arcanedev\LogViewer\Exceptions\LogNotFoundException;
 
 /**
  * Class     LogViewer
@@ -184,12 +182,7 @@ class LogViewer implements LogViewerContract
      */
     public function get($date)
     {
-        $dates = $this->filesystem->dates(true);
-        if (!isset($dates[$date])) {
-            throw new LogNotFoundException("Log not found in this date [$date]");
-        }
-
-        return new Log($date, $dates[$date], $this->filesystem->read($date));
+        return $this->factory->log($date);
     }
 
     /**
@@ -202,7 +195,7 @@ class LogViewer implements LogViewerContract
      */
     public function entries($date, $level = 'all')
     {
-        return $this->get($date)->entries($level);
+        return $this->factory->entries($date, $level);
     }
 
     /**
@@ -286,7 +279,7 @@ class LogViewer implements LogViewerContract
      */
     public function dates()
     {
-        return $this->filesystem->dates();
+        return $this->factory->dates();
     }
 
     /**

--- a/src/Utilities/Factory.php
+++ b/src/Utilities/Factory.php
@@ -8,6 +8,8 @@ use Arcanedev\LogViewer\Contracts\Utilities\Factory as FactoryContract;
 use Arcanedev\LogViewer\Contracts\Utilities\Filesystem as FilesystemContract;
 use Arcanedev\LogViewer\Contracts\Utilities\LogLevels as LogLevelsContract;
 use Arcanedev\LogViewer\Entities\LogCollection;
+use Arcanedev\LogViewer\Entities\Log;
+use Arcanedev\LogViewer\Exceptions\LogNotFoundException;
 use Arcanedev\LogViewer\Tables\StatsTable;
 
 /**
@@ -196,7 +198,12 @@ class Factory implements FactoryContract
      */
     public function log($date)
     {
-        return $this->logs()->log($date);
+        $dates = $this->filesystem->dates(true);
+        if (!isset($dates[$date])) {
+            throw new LogNotFoundException("Log not found in this date [$date]");
+        }
+
+        return new Log($date, $dates[$date], $this->filesystem->read($date));
     }
 
     /**
@@ -221,7 +228,7 @@ class Factory implements FactoryContract
      */
     public function entries($date, $level = 'all')
     {
-        return $this->logs()->entries($date, $level);
+        return $this->log($date)->entries($level);
     }
 
     /**
@@ -253,7 +260,7 @@ class Factory implements FactoryContract
      */
     public function dates()
     {
-        return $this->logs()->dates();
+        return $this->filesystem->dates();
     }
 
     /**


### PR DESCRIPTION
With many log files log view take minimum 5 sec to load, because even you need only one log it reads ALL.

PS. Will be nice if this change backported to older versions of package