### PR TITLE
[French translation] Fix minor typo

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,6 +1,6 @@
 {
     "Date": "Date",
-    "The list of logs is empty!": "La liste des logs est vide!",
+    "The list of logs is empty!": "La liste des logs est vide !",
     "All": "Tous",
     "Emergency": "Urgence",
     "Alert": "Alerte",


### PR DESCRIPTION
In French (except in Canadian French), there is a space before exclamation marks

As fr default region is typically France (but this also applies to Belgium and Switzerland for instance), I suggest to add the space and optionally use a fr_CA.json file that would extend fr.json and override this sentence only to handle the Canadian variations.