### PR TITLE
Allow suffix in pattern.

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -17,8 +17,9 @@ return [
      */
 
     'pattern'       => [
-        'prefix'    => Filesystem::PATTERN_PREFIX,    // 'laravel-'
+        'prefix'    => Filesystem::PATTERN_PREFIX,     // 'laravel-'
         'date'      => Filesystem::PATTERN_DATE,      // '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+        'suffix'    => '',                            // '-{webapp,root}'
         'extension' => Filesystem::PATTERN_EXTENSION, // '.log'
     ],
 

--- a/src/Contracts/Patternable.php
+++ b/src/Contracts/Patternable.php
@@ -37,6 +37,7 @@ interface Patternable
     public function setPattern(
         $prefix    = Filesystem::PATTERN_PREFIX,
         $date      = Filesystem::PATTERN_DATE,
+        $suffix    = Filesystem::PATTERN_SUFFIX,
         $extension = Filesystem::PATTERN_EXTENSION
     );
 }

--- a/src/Helpers/LogParser.php
+++ b/src/Helpers/LogParser.php
@@ -83,7 +83,10 @@ class LogParser
      */
     public static function extractDate(string $string): string
     {
-        return preg_replace('/.*('.self::REGEX_DATE_PATTERN.').*/', '$1', $string);
+        $regexDate = self::REGEX_DATE_PATTERN;
+        $suffix = config('log-viewer.pattern.suffix', "");
+
+        return preg_replace('/.*('.$regexDate.$suffix.').*/', '$1', $string);
     }
 
     /**

--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -176,7 +176,9 @@ class LogViewerController extends Controller
      */
     public function download($date)
     {
-        return $this->logViewer->download($date);
+        $filename = empty(config('log-viewer.pattern.suffix')) ? null : $date;
+                
+        return $this->logViewer->download($date, $filename);
     }
 
     /**

--- a/src/LogViewer.php
+++ b/src/LogViewer.php
@@ -130,8 +130,9 @@ class LogViewer implements LogViewerContract
     /**
      * Set the log pattern.
      *
-     * @param string $date
      * @param string $prefix
+     * @param string $date
+     * @param string $suffix
      * @param string $extension
      *
      * @return self
@@ -139,9 +140,10 @@ class LogViewer implements LogViewerContract
     public function setPattern(
         $prefix = FilesystemContract::PATTERN_PREFIX,
         $date = FilesystemContract::PATTERN_DATE,
+        $suffix = FilesystemContract::PATTERN_SUFFIX,
         $extension = FilesystemContract::PATTERN_EXTENSION
     ) {
-        $this->factory->setPattern($prefix, $date, $extension);
+        $this->factory->setPattern($prefix, $date, $suffix, $extension);
 
         return $this;
     }

--- a/src/Providers/DeferredServicesProvider.php
+++ b/src/Providers/DeferredServicesProvider.php
@@ -115,6 +115,7 @@ class DeferredServicesProvider extends ServiceProvider implements DeferrableProv
             return $filesystem->setPattern(
                 $config->get('log-viewer.pattern.prefix', FilesystemContract::PATTERN_PREFIX),
                 $config->get('log-viewer.pattern.date', FilesystemContract::PATTERN_DATE),
+                $config->get('log-viewer.pattern.suffix', FilesystemContract::PATTERN_SUFFIX),
                 $config->get('log-viewer.pattern.extension', FilesystemContract::PATTERN_EXTENSION)
             );
         });

--- a/src/Utilities/Factory.php
+++ b/src/Utilities/Factory.php
@@ -134,8 +134,9 @@ class Factory implements FactoryContract
     /**
      * Set the log pattern.
      *
-     * @param  string  $date
      * @param  string  $prefix
+     * @param  string  $date
+     * @param  string  $suffix
      * @param  string  $extension
      *
      * @return self
@@ -143,9 +144,10 @@ class Factory implements FactoryContract
     public function setPattern(
         $prefix    = FilesystemContract::PATTERN_PREFIX,
         $date      = FilesystemContract::PATTERN_DATE,
+        $suffix = FilesystemContract::PATTERN_SUFFIX,
         $extension = FilesystemContract::PATTERN_EXTENSION
     ) {
-        $this->filesystem->setPattern($prefix, $date, $extension);
+        $this->filesystem->setPattern($prefix, $date, $suffix, $extension);
 
         return $this;
     }

--- a/src/Utilities/Filesystem.php
+++ b/src/Utilities/Filesystem.php
@@ -42,6 +42,13 @@ class Filesystem implements FilesystemContract
      * @var string
      */
     protected $prefixPattern;
+    
+    /**
+     * The log files suffix pattern.
+     *
+     * @var string
+     */
+    protected $suffixPattern;
 
     /**
      * The log files date pattern.
@@ -111,14 +118,15 @@ class Filesystem implements FilesystemContract
      */
     public function getPattern(): string
     {
-        return $this->prefixPattern.$this->datePattern.$this->extension;
+        return $this->prefixPattern.$this->datePattern.$this->suffixPattern.$this->extension;
     }
 
     /**
      * Set the log pattern.
      *
-     * @param  string  $date
      * @param  string  $prefix
+     * @param  string  $date
+     * @param  string  $suffix
      * @param  string  $extension
      *
      * @return $this
@@ -126,10 +134,12 @@ class Filesystem implements FilesystemContract
     public function setPattern(
         $prefix    = self::PATTERN_PREFIX,
         $date      = self::PATTERN_DATE,
+        $suffix    = self::PATTERN_SUFFIX,
         $extension = self::PATTERN_EXTENSION
     ) {
         $this->setPrefixPattern($prefix);
         $this->setDatePattern($date);
+        $this->setSuffixPattern($suffix);
         $this->setExtension($extension);
 
         return $this;
@@ -159,6 +169,20 @@ class Filesystem implements FilesystemContract
     public function setPrefixPattern($prefixPattern)
     {
         $this->prefixPattern = $prefixPattern;
+
+        return $this;
+    }
+    
+    /**
+     * Set the log suffix pattern.
+     *
+     * @param  string  $suffixPattern
+     *
+     * @return $this
+     */
+    public function setSuffixPattern($suffixPattern)
+    {
+        $this->suffixPattern = $suffixPattern;
 
         return $this;
     }
@@ -211,7 +235,8 @@ class Filesystem implements FilesystemContract
      */
     public function dates($withPaths = false)
     {
-        $files = array_reverse($this->logs());
+        $files = $this->logs();
+        rsort($files);
         $dates = $this->extractDates($files);
 
         if ($withPaths) {
@@ -316,7 +341,9 @@ class Filesystem implements FilesystemContract
      */
     private function getLogPath(string $date)
     {
-        $path = $this->storagePath.DIRECTORY_SEPARATOR.$this->prefixPattern.$date.$this->extension;
+        $path = empty(config('log-viewer.pattern.suffix'))
+                ? $this->storagePath.DIRECTORY_SEPARATOR.$this->prefixPattern.$date.$this->extension
+                : $this->storagePath.DIRECTORY_SEPARATOR.$date;
 
         if ( ! $this->filesystem->exists($path)) {
             throw FilesystemException::invalidPath($path);

--- a/views/bootstrap-4/logs.blade.php
+++ b/views/bootstrap-4/logs.blade.php
@@ -31,7 +31,16 @@
                         @foreach($row as $key => $value)
                             <td class="{{ $key == 'date' ? 'text-left' : 'text-center' }}">
                                 @if ($key == 'date')
+                                    @if(empty($suffix = config('log-viewer.pattern.suffix')))
                                     <span class="badge badge-primary">{{ $value }}</span>
+                                    @else
+                                    <span class="badge badge-primary">
+                                        {{ \Str::beforeLast(\Str::after($value, config('log-viewer.pattern.prefix', "")), mb_substr($suffix, 0, 1)); }}
+                                    </span>
+                                    <span class="ml-1">
+                                        {{ \Str::afterLast(\Str::after($value, config('log-viewer.pattern.prefix', "")), mb_substr($suffix, 0, 1)); }}
+                                    </span>
+                                    @endif
                                 @elseif ($value == 0)
                                     <span class="badge empty">{{ $value }}</span>
                                 @else


### PR DESCRIPTION
These small modifications allow the display of multiple env logs with the same date. 

For example:

  'suffix'    => '-{webapp,root}'

 it will show: laravel-2022-04-18-webapp.log, laravel-2022-04-18-root.log

Another example:

 'suffix'    => '-{cli,pm-fcgi}'

 it will show: laravel-2022-04-18-cli.log, laravel-2022-04-18-fpm-fcgi.log


Related: [#135](https://github.com/ARCANEDEV/LogViewer/issues/135), [#65](https://github.com/ARCANEDEV/LogViewer/issues/65)

![Captura de pantalla de 2022-04-18 22-09-14](https://user-images.githubusercontent.com/1129993/163870238-15f13403-c090-4cfb-becd-1b53aa63dd3d.png)

