### PR TITLE
Add show route config

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -55,6 +55,8 @@ return [
 
             'middleware' => env('ARCANEDEV_LOGVIEWER_MIDDLEWARE') ? explode(',', env('ARCANEDEV_LOGVIEWER_MIDDLEWARE')) : null,
         ],
+
+        'show' => 'log-viewer::logs.show'
     ],
 
     /* -----------------------------------------------------------------

--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -52,6 +52,7 @@ class LogViewerController extends Controller
     {
         $this->logViewer = $logViewer;
         $this->perPage = config('log-viewer.per-page', $this->perPage);
+        $this->showRoute = config('log-viewer.route.show', $this->showRoute);
     }
 
     /* -----------------------------------------------------------------


### PR DESCRIPTION
This PR fixes `Route [log-viewer::logs.show] not defined` error when using custom route, or setting `route.enabled` to `false` in `config/log-viewer.php` (line 51). This happens because `$showRoute` variable is hardcoded to `log-viewer::logs.show` in `LogViewerController` (line 39).